### PR TITLE
Feature#79: 프로젝트 이미지 및 비디오 LazyLoad 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-ga4": "^2.1.0",
+        "react-intersection-observer": "^9.14.1",
         "react-lazyload": "^3.2.1",
         "react-router-dom": "^6.26.2",
         "react-transition-group": "^4.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       react-ga4:
         specifier: ^2.1.0
         version: 2.1.0
+      react-intersection-observer:
+        specifier: ^9.14.1
+        version: 9.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-lazyload:
         specifier: ^3.2.1
         version: 3.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3205,6 +3208,15 @@ packages:
 
   react-ga4@2.1.0:
     resolution: {integrity: sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==}
+
+  react-intersection-observer@9.14.1:
+    resolution: {integrity: sha512-k1xIUn3sCQi3ugNeF64FJb3zwve5mcetvAUR9JazXeOmtap4IP2evN8rs+yf6SQ7F1QydsOGiqTmt+lySKZ9uA==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -7694,6 +7706,12 @@ snapshots:
       react-is: 18.1.0
 
   react-ga4@2.1.0: {}
+
+  react-intersection-observer@9.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
 
   react-is@16.13.1: {}
 

--- a/src/components/ProjectPage/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectPage/ProjectCard/ProjectCard.tsx
@@ -1,6 +1,10 @@
+import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { preloadImages } from "@/utils/preload";
+
 import * as CardStyles from "./ProjectCard.style";
+import { data } from "@/apps/data";
 import { Text } from "@/common/components/Text/Text";
 import { useProjectEvent } from "@/events/projectEvents";
 
@@ -16,9 +20,17 @@ export const ProjectCard = (props: ProjectCardProps) => {
 
     const { dispatchMouseOverEvent, dispatchMouseClickEvent } = useProjectEvent(props.id);
 
+    const handleMouseOver = useCallback(() => {
+        const headerImage = data[props.id - 1].project.contents[0];
+        const firstProjectImage = data[props.id - 1].project.contents[1];
+
+        preloadImages([headerImage, firstProjectImage]);
+        dispatchMouseOverEvent();
+    }, [dispatchMouseOverEvent, props.id]);
+
     return (
         <CardStyles.Wrapper
-            onMouseOver={dispatchMouseOverEvent}
+            onMouseOver={handleMouseOver}
             onClick={() => {
                 navigate(`?section=project&id=${props.id - 1}`);
                 dispatchMouseClickEvent();

--- a/src/components/ProjectPage/ProjectImage/ProjectImage.style.ts
+++ b/src/components/ProjectPage/ProjectImage/ProjectImage.style.ts
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+
+export const ImageWrapper = styled.div`
+    width: 100%;
+`;
+
+export const Image = styled.img`
+    display: block;
+    width: 100%;
+    margin: 0px auto;
+`;

--- a/src/components/ProjectPage/ProjectImage/ProjectImage.tsx
+++ b/src/components/ProjectPage/ProjectImage/ProjectImage.tsx
@@ -1,0 +1,20 @@
+import { useInView } from "react-intersection-observer";
+
+import * as ProjectImageStyles from "./ProjectImage.style";
+
+export interface ProjectImageProps extends React.ComponentProps<"img"> {
+    offset: number;
+}
+
+export const ProjectImage = ({ src, offset, ...rest }: ProjectImageProps) => {
+    const { ref, inView } = useInView({
+        triggerOnce: true,
+        rootMargin: `${offset}px`,
+    });
+
+    return (
+        <ProjectImageStyles.ImageWrapper ref={ref} style={{ minHeight: `${offset}px` }}>
+            {inView && <ProjectImageStyles.Image src={src} {...rest} />}
+        </ProjectImageStyles.ImageWrapper>
+    );
+};

--- a/src/components/ProjectPage/ProjectVideo/ProjectVideo.style.ts
+++ b/src/components/ProjectPage/ProjectVideo/ProjectVideo.style.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+export const VideoWrapper = styled.div`
+    width: 100%;
+`;
+
+export const Video = styled.video`
+    display: block;
+    width: 100%;
+    margin: 0px auto;
+    border: 0;
+    padding: 0;
+`;

--- a/src/components/ProjectPage/ProjectVideo/ProjectVideo.tsx
+++ b/src/components/ProjectPage/ProjectVideo/ProjectVideo.tsx
@@ -1,0 +1,20 @@
+import { useInView } from "react-intersection-observer";
+
+import * as ProjectVideoStyles from "./ProjectVideo.style";
+
+export interface ProjectVideoProps extends React.ComponentProps<"video"> {
+    offset: number;
+}
+
+export const ProjectVideo = ({ src, offset, ...rest }: ProjectVideoProps) => {
+    const { ref, inView } = useInView({
+        triggerOnce: true,
+        rootMargin: `${offset}px`,
+    });
+
+    return (
+        <ProjectVideoStyles.VideoWrapper ref={ref} style={{ minHeight: `${offset}px` }}>
+            {inView && <ProjectVideoStyles.Video src={src} autoPlay loop muted playsInline {...rest} />}
+        </ProjectVideoStyles.VideoWrapper>
+    );
+};

--- a/src/pages/ProjectPage/ProjectDetailPage.style.ts
+++ b/src/pages/ProjectPage/ProjectDetailPage.style.ts
@@ -75,6 +75,7 @@ export const Body = styled.div`
     display: block;
     width: 100%;
     max-width: 980px;
+    min-height: 100vh;
 
     margin: 0px auto;
     margin-top: 60px;

--- a/src/pages/ProjectPage/ProjectDetailPage.tsx
+++ b/src/pages/ProjectPage/ProjectDetailPage.tsx
@@ -1,6 +1,9 @@
 import { memo, useLayoutEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { ProjectImage } from "@/components/ProjectPage/ProjectImage/ProjectImage";
+import { ProjectVideo } from "@/components/ProjectPage/ProjectVideo/ProjectVideo";
+
 import { useProjectId } from "@/hooks/ProjectPage/useProjectId";
 
 import { LeftArrow } from "@/assets/icons/LeftArrow";
@@ -91,9 +94,8 @@ export default memo(function ProjectDetailPage() {
                 </ProjectDetailStyles.ContentWrapper>
 
                 {data[projectId].project.contents.map((src) => {
-                    if (src.match(/\.(webp|gif)$/)) return <ProjectDetailStyles.Image src={src} />;
-                    else if (src.match(/\.(webm|mp4)$/))
-                        return <ProjectDetailStyles.Video src={src} autoPlay loop muted playsInline />;
+                    if (src.match(/\.(webp|gif)$/)) return <ProjectImage src={src} offset={400} />;
+                    else if (src.match(/\.(webm|mp4)$/)) return <ProjectVideo src={src} offset={800} />;
                 })}
             </ProjectDetailStyles.Body>
         </ProjectDetailStyles.PageWrapper>


### PR DESCRIPTION
## ✨ 구현한 기능

- resolve #79 
- 프로젝트 상세페이지의 이미지 및 비디오 요소를 LazyLoad 를 적용하였습니다
- 프로젝트 목록페이지에서 프로젝트 카드 컴포넌트 (`ProjectCard`) 마우스 호버시, 
   프로젝트 상세페이지의 첫번째 그리고 두번째 이미지를 사전로드하였습니다.

## 🎸 기타

- 뷰포트 기반 이미지로드를 위해 `react-intersection-observer` 패키지를 설치하였습니다
