### PR TITLE
Fix#86 프로젝트 상세페이지 이동시 헤더이미지 로드로 인한 layout shift 현상 해결

### DIFF
--- a/src/domains/project/components/ProjectCard/ProjectCard.tsx
+++ b/src/domains/project/components/ProjectCard/ProjectCard.tsx
@@ -23,10 +23,10 @@ export const ProjectCard = (props: ProjectCardProps) => {
     const { dispatchMouseOverEvent, dispatchMouseClickEvent } = useProjectEvent(props.id);
 
     const handleMouseOver = useCallback(() => {
-        const headerImage = data[props.id - 1].project.contents[0];
-        const firstProjectImage = data[props.id - 1].project.contents[1];
+        const headerImage = data[props.id - 1].project.thumbnail;
+        const projectImage = [data[props.id - 1].project.contents[0], data[props.id - 1].project.contents[1]];
 
-        preloadImages([headerImage, firstProjectImage]);
+        preloadImages([headerImage, ...projectImage]);
         dispatchMouseOverEvent();
     }, [dispatchMouseOverEvent, props.id]);
 

--- a/src/pages/project/ProjectDetailPage.style.ts
+++ b/src/pages/project/ProjectDetailPage.style.ts
@@ -95,14 +95,7 @@ export const Image = styled.img`
     display: block;
     margin: 0px auto;
     width: 100%;
-`;
-
-export const Video = styled.video`
-    display: block;
-    margin: 0px auto;
-    border: 0;
-    padding: 0;
-    width: 100%;
+    aspect-ratio: 1920 / 1000;
 `;
 
 export const ContentWrapper = styled.div`


### PR DESCRIPTION
## ✨ 구현한 기능

- resolve #86 

- 프로젝트 상세페이지 이동시 헤더이미지 로드로 인한 layout shift 현상 해결
  - 프로젝트 목록페이지 카드 호버시 상세페이지의 헤더 이미지 사전 로드하도록 하여 layout shift 개선
  - 프로젝트 상세페이지의 헤더 이미지에 `aspect-ratio : 1920/1000` 설정으로, 이미지 사전로딩이 되지 않더라도 layout shift 발생하지 않도록 변경
